### PR TITLE
Add support for numbers greater than 5_000

### DIFF
--- a/src/roman.py
+++ b/src/roman.py
@@ -45,8 +45,21 @@ class InvalidRomanNumeralError(RomanError):
     pass
 
 
+
 # Define digit mapping
-romanNumeralMap = (('M', 1000),
+romanNumeralMap = (('M̄', 1_000_000),
+                   ('C̄M̄', 900_000),
+                   ('D̄', 500_000),
+                   ('C̄D̄', 400_000),
+                   ('C̄', 100_000),
+                   ('X̄C̄', 90_000),
+                   ('L̄', 50_000),
+                   ('X̄L̄', 40_000),
+                   ('X̄', 10_000),
+                   ('ĪX̄', 9_000),
+                   ('V̄', 5_000),
+                   ('ĪV̄', 4_000),
+                   ('M', 1000),
                    ('CM', 900),
                    ('D', 500),
                    ('CD', 400),
@@ -65,8 +78,8 @@ def toRoman(n):
     """convert integer to Roman numeral"""
     if not isinstance(n, int):
         raise NotIntegerError("decimals cannot be converted")
-    if not (-1 < n < 5000):
-        raise OutOfRangeError("number out of range (must be 0..4999)")
+    if not (-1 < n < 3_999_999):
+        raise OutOfRangeError("number out of range (must be 0..3,999,999)")
 
     # special case
     if n == 0:
@@ -81,8 +94,13 @@ def toRoman(n):
 
 
 # Define pattern to detect valid Roman numerals
+# Ī is U+012A, the other overlined characters are made with U+0304.
 romanNumeralPattern = re.compile("""
     ^                   # beginning of string
+    M̄{0,4}
+    (C̄M̄|C̄D̄|D̄?C̄{0,3})
+    (X̄C̄|X̄L̄|L̄?X̄{0,3})
+    (ĪX̄|ĪV̄|V̄?Ī{0,3})
     M{0,4}              # thousands - 0 to 4 M's
     (CM|CD|D?C{0,3})    # hundreds - 900 (CM), 400 (CD), 0-300 (0 to 3 C's),
                         #            or 500-800 (D, followed by 0 to 3 C's)

--- a/src/roman.py
+++ b/src/roman.py
@@ -45,7 +45,6 @@ class InvalidRomanNumeralError(RomanError):
     pass
 
 
-
 # Define digit mapping
 romanNumeralMap = (('M̄', 1_000_000),
                    ('C̄M̄', 900_000),

--- a/src/tests.py
+++ b/src/tests.py
@@ -23,7 +23,7 @@ TEST_MAP = ((0, 'N'), (1, 'I'), (3, 'III'), (4, 'IV'), (9, 'IX'), (14, 'XIV'),
             (19, 'XIX'), (24, 'XXIV'), (40, 'XL'), (49, 'XLIX'), (90, 'XC'),
             (99, 'XCIX'), (400, 'CD'), (490, 'CDXC'), (499, 'CDXCIX'),
             (900, 'CM'), (990, 'CMXC'), (998, 'CMXCVIII'), (999, 'CMXCIX'),
-            (2013, 'MMXIII'), (1666666, 'M̄D̄C̄L̄X̄V̄MDCLXVI'))
+            (2013, 'MMXIII'), (999_999, 'C̄M̄X̄C̄ĪX̄CMXCIX'), (1_666_666, 'M̄D̄C̄L̄X̄V̄MDCLXVI'))
 
 
 class TestRoman(unittest.TestCase):

--- a/src/tests.py
+++ b/src/tests.py
@@ -23,7 +23,7 @@ TEST_MAP = ((0, 'N'), (1, 'I'), (3, 'III'), (4, 'IV'), (9, 'IX'), (14, 'XIV'),
             (19, 'XIX'), (24, 'XXIV'), (40, 'XL'), (49, 'XLIX'), (90, 'XC'),
             (99, 'XCIX'), (400, 'CD'), (490, 'CDXC'), (499, 'CDXCIX'),
             (900, 'CM'), (990, 'CMXC'), (998, 'CMXCVIII'), (999, 'CMXCIX'),
-            (2013, 'MMXIII'))
+            (2013, 'MMXIII'), (1666666, 'M̄D̄C̄L̄X̄V̄MDCLXVI'))
 
 
 class TestRoman(unittest.TestCase):

--- a/src/tests.py
+++ b/src/tests.py
@@ -23,7 +23,8 @@ TEST_MAP = ((0, 'N'), (1, 'I'), (3, 'III'), (4, 'IV'), (9, 'IX'), (14, 'XIV'),
             (19, 'XIX'), (24, 'XXIV'), (40, 'XL'), (49, 'XLIX'), (90, 'XC'),
             (99, 'XCIX'), (400, 'CD'), (490, 'CDXC'), (499, 'CDXCIX'),
             (900, 'CM'), (990, 'CMXC'), (998, 'CMXCVIII'), (999, 'CMXCIX'),
-            (2013, 'MMXIII'), (999_999, 'C̄M̄X̄C̄ĪX̄CMXCIX'), (1_666_666, 'M̄D̄C̄L̄X̄V̄MDCLXVI'))
+            (2013, 'MMXIII'), (999_999, 'C̄M̄X̄C̄ĪX̄CMXCIX'),
+            (1_666_666, 'M̄D̄C̄L̄X̄V̄MDCLXVI'))
 
 
 class TestRoman(unittest.TestCase):


### PR DESCRIPTION
Refs https://github.com/zopefoundation/roman/issues/19

TODO:

- [ ] Fix Regex for determing roman numbers. I think, some mixed cases are also possible. `IM̄` for 999,999. Or is this `C̄M̄X̄C̄ĪX̄CMXCIX` as suggested by https://stackoverflow.com/a/50012689/873282?
- [ ] Add more tests